### PR TITLE
Added paths for OS X Homebrew installation of `icu`

### DIFF
--- a/text-icu-translit.cabal
+++ b/text-icu-translit.cabal
@@ -26,7 +26,10 @@ library
 
   c-sources: cbits/trans.c
   include-dirs: include
-
+  
+  if os(darwin)
+    extra-lib-dirs: /usr/local/opt/icu4c/lib
+    include-dirs: /usr/local/opt/icu4c/include
   extra-libraries: icuuc
   if os(mingw32)
     extra-libraries: icuin icudt


### PR DESCRIPTION
Using the same approach as in https://github.com/bos/text-icu/pull/20