### PR TITLE
fix: use `castPtr` to avoid error on new text library

### DIFF
--- a/Data/Text/ICU/Translit/IO.hs
+++ b/Data/Text/ICU/Translit/IO.hs
@@ -34,7 +34,7 @@ instance Show Transliterator where
 transliterator :: Text -> IO Transliterator
 transliterator spec =
     useAsPtr spec $ \ptr len -> do
-           q <- handleError $ openTrans ptr (fromIntegral len)
+           q <- handleError $ openTrans (castPtr ptr) (fromIntegral len)
            ref <- newForeignPtr closeTrans q
            touchForeignPtr ref
            return $ Transliterator ref spec
@@ -47,7 +47,7 @@ transliterate tr txt = do
       withForeignPtr (transPtr tr) $ \tr_ptr -> do
              handleFilledOverflowError ptr (fromIntegral len)
                  (\dptr dlen ->
-                        doTrans tr_ptr dptr (fromIntegral len) (fromIntegral dlen))
+                        doTrans tr_ptr (castPtr dptr) (fromIntegral len) (fromIntegral dlen))
                  (\dptr dlen ->
                         fromPtr (castPtr dptr) (fromIntegral dlen))
 


### PR DESCRIPTION
I had to deal with the `useAsPtr` in the new version of the text library, which seems to pass `Ptr Word8` instead of `Ptr UChar`. It is probably safe to use `castPtr` for the same length, so I used it to solve the problem. I think it's safe to assume that the version that depends on the old text will just be the same with cast.