### PR TITLE
Fix text-icu-translit to work for newer versions of text

### DIFF
--- a/Data/Text/ICU/Translit/IO.hs
+++ b/Data/Text/ICU/Translit/IO.hs
@@ -6,7 +6,7 @@ module Data.Text.ICU.Translit.IO
  where
 
 import Foreign
-import Data.Text
+import Data.Text (Text)
 import Data.Text.Foreign
 import Data.Text.ICU.Translit.ICUHelper
 #if MIN_VERSION_text(2,0,0)

--- a/Data/Text/ICU/Translit/IO.hs
+++ b/Data/Text/ICU/Translit/IO.hs
@@ -1,12 +1,14 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TupleSections #-}
+
 module Data.Text.ICU.Translit.IO
-    (Transliterator,
-     transliterator,
-     transliterate) where
+ where
 
 import Foreign
 import Data.Text
 import Data.Text.Foreign
 import Data.Text.ICU.Translit.ICUHelper
+import Foreign.C.String (CString)
 
 data UTransliterator
 
@@ -33,7 +35,7 @@ instance Show Transliterator where
 
 transliterator :: Text -> IO Transliterator
 transliterator spec =
-    useAsPtr spec $ \ptr len -> do
+    useAsUCharPtr spec $ \ptr len -> do
            q <- handleError $ openTrans ptr (fromIntegral len)
            ref <- newForeignPtr closeTrans q
            touchForeignPtr ref
@@ -42,13 +44,54 @@ transliterator spec =
 
 transliterate :: Transliterator -> Text -> IO Text
 transliterate tr txt = do
-  (fptr, len) <- asForeignPtr txt
+  (fptr, len) <- asUCharForeignPtr txt
   withForeignPtr fptr $ \ptr ->
       withForeignPtr (transPtr tr) $ \tr_ptr -> do
              handleFilledOverflowError ptr (fromIntegral len)
                  (\dptr dlen ->
                         doTrans tr_ptr dptr (fromIntegral len) (fromIntegral dlen))
                  (\dptr dlen ->
-                        fromPtr (castPtr dptr) (fromIntegral dlen))
+                        fromUCharPtr dptr (fromIntegral dlen))
 
 
+-- Stolen from a hidden module from https://github.com/haskell/text-icu
+
+useAsUCharPtr :: Text -> (Ptr UChar -> I16 -> IO a) -> IO a
+useAsUCharPtr t act = useAsPtr t $ \tptr tlen ->
+    allocaArray (fromIntegral tlen) $ \ dst ->
+        act dst =<< fromUtf8 dst tptr tlen
+
+asUCharForeignPtr :: Text -> IO (ForeignPtr UChar, I16)
+asUCharForeignPtr t = useAsPtr t $ \tptr tlen -> do
+    fp <- mallocForeignPtrArray (fromIntegral tlen)
+    withForeignPtr fp $ \ dst -> (fp,) <$> fromUtf8 dst tptr tlen
+
+fromUtf8 :: Ptr UChar -> Ptr Word8 -> I8 -> IO I16
+fromUtf8 dst tptr tlen =
+    with 0 $ \ err ->
+    with 0 $ \ dstLen -> do
+        _ <- u_strFromUTF8Lenient dst (fromIntegral tlen) dstLen tptr
+              (fromIntegral tlen) err
+        fromIntegral <$> peek dstLen
+
+fromUCharPtr :: Ptr UChar -> I16 -> IO Text
+fromUCharPtr p l =
+    with 0 $ \ err ->
+    with 0 $ \ dstLen ->
+    allocaArray capacity $ \ dst -> do
+        _ <- u_strToUTF8 dst (fromIntegral capacity) dstLen p
+            (fromIntegral l) err
+        dl <- peek dstLen
+        fromPtr dst (fromIntegral dl)
+    where capacity = fromIntegral l * 3
+
+foreign import ccall "text_icu.h __hs_u_strFromUTF8Lenient" u_strFromUTF8Lenient
+    :: Ptr UChar -> Int32 -> Ptr Int32 -> Ptr Word8 -> Int32 -> Ptr UErrorCode
+    -> IO CString
+
+foreign import ccall "text_icu.h __hs_u_strToUTF8" u_strToUTF8
+    :: Ptr Word8 -> Int32 -> Ptr Int32 -> Ptr UChar -> Int32 -> Ptr UErrorCode
+    -> IO CString
+
+newtype I16 = I16 Int
+    deriving (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)

--- a/Data/Text/ICU/Translit/IO.hs
+++ b/Data/Text/ICU/Translit/IO.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE CPP #-}
 
 module Data.Text.ICU.Translit.IO
  where
@@ -8,7 +9,9 @@ import Foreign
 import Data.Text
 import Data.Text.Foreign
 import Data.Text.ICU.Translit.ICUHelper
+#if MIN_VERSION_text(2,0,0)
 import Foreign.C.String (CString)
+#endif
 
 data UTransliterator
 
@@ -35,7 +38,7 @@ instance Show Transliterator where
 
 transliterator :: Text -> IO Transliterator
 transliterator spec =
-    useAsUCharPtr spec $ \ptr len -> do
+    compatUseAsPtr spec $ \ptr len -> do
            q <- handleError $ openTrans ptr (fromIntegral len)
            ref <- newForeignPtr closeTrans q
            touchForeignPtr ref
@@ -44,18 +47,34 @@ transliterator spec =
 
 transliterate :: Transliterator -> Text -> IO Text
 transliterate tr txt = do
-  (fptr, len) <- asUCharForeignPtr txt
+  (fptr, len) <- compatAsForeignPtr txt
   withForeignPtr fptr $ \ptr ->
       withForeignPtr (transPtr tr) $ \tr_ptr -> do
              handleFilledOverflowError ptr (fromIntegral len)
                  (\dptr dlen ->
                         doTrans tr_ptr dptr (fromIntegral len) (fromIntegral dlen))
                  (\dptr dlen ->
-                        fromUCharPtr dptr (fromIntegral dlen))
+                        compatFromPtr dptr (fromIntegral dlen))
 
+
+
+compatUseAsPtr :: Text -> (Ptr UChar -> I16 -> IO a) -> IO a
+compatAsForeignPtr :: Text -> IO (ForeignPtr UChar, I16)
+compatFromPtr :: Ptr UChar -> I16 -> IO Text
+
+#if !MIN_VERSION_text(2,0,0)
+
+compatUseAsPtr = useAsPtr
+compatAsForeignPtr = asForeignPtr
+compatFromPtr = fromPtr
+
+#else
+
+compatUseAsPtr = useAsUCharPtr
+compatAsForeignPtr = asUCharForeignPtr
+compatFromPtr = fromUCharPtr
 
 -- Stolen from a hidden module from https://github.com/haskell/text-icu
-
 useAsUCharPtr :: Text -> (Ptr UChar -> I16 -> IO a) -> IO a
 useAsUCharPtr t act = useAsPtr t $ \tptr tlen ->
     allocaArray (fromIntegral tlen) $ \ dst ->
@@ -95,3 +114,5 @@ foreign import ccall "text_icu.h __hs_u_strToUTF8" u_strToUTF8
 
 newtype I16 = I16 Int
     deriving (Bounded, Enum, Eq, Integral, Num, Ord, Read, Real, Show)
+
+#endif

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -4,6 +4,7 @@ import Test.QuickCheck
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.ICU as U
+import qualified Data.Text.ICU.Normalize2 as UN
 import Data.Text.ICU.Translit
 import Text.Printf
 import Data.Char
@@ -43,7 +44,7 @@ prop_idemp (IdempTr t,s) = transliterate tr (transliterate tr s) == transliterat
     where tr = trans t
 prop_toLower' t = U.toLower U.Root t == transliterate (trans "Lower") t
 prop_toLower t = T.toLower t == transliterate (trans "Lower") t
-prop_NFC t = U.normalize U.NFC t == transliterate (trans "NFC") t
+prop_NFC t = UN.normalize UN.NFC t == transliterate (trans "NFC") t
 prop_hexUnicode t = hexUnicode t == transliterate (trans "hex/unicode") t
 
 

--- a/text-icu-translit.cabal
+++ b/text-icu-translit.cabal
@@ -34,7 +34,7 @@ library
     extra-libraries: icui18n icudata
 
   -- other-extensions:    
-  build-depends:       base >=4 && <5, text >= 2.0, text-icu >= 0.8.0.0
+  build-depends:       base >=4 && <5, text >= 1.0, text-icu >= 0.6.3
   -- hs-source-dirs:      
   default-language:    Haskell2010
 
@@ -43,8 +43,8 @@ test-suite tests
   default-language:    Haskell2010
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base, text >= 2.0,
-                       text-icu >= 0.8.0.0,
+  build-depends:       base, text >= 1.0,
+                       text-icu >= 0.6.3,
                        text-icu-translit,
                        QuickCheck >= 2.4,
                        test-framework >= 0.8,

--- a/text-icu-translit.cabal
+++ b/text-icu-translit.cabal
@@ -1,6 +1,6 @@
 
 name:                text-icu-translit
-version:             0.1.1.0
+version:             0.1.1.1
 synopsis:            ICU transliteration
 description:
   Bindings to the transliteration features by the

--- a/text-icu-translit.cabal
+++ b/text-icu-translit.cabal
@@ -1,6 +1,6 @@
 
 name:                text-icu-translit
-version:             0.1.0.7
+version:             0.1.1.0
 synopsis:            ICU transliteration
 description:
   Bindings to the transliteration features by the
@@ -34,7 +34,7 @@ library
     extra-libraries: icui18n icudata
 
   -- other-extensions:    
-  build-depends:       base >=4 && <5, text >= 1.0
+  build-depends:       base >=4 && <5, text >= 2.0, text-icu >= 0.8.0.0
   -- hs-source-dirs:      
   default-language:    Haskell2010
 
@@ -43,8 +43,8 @@ test-suite tests
   default-language:    Haskell2010
   hs-source-dirs:      tests
   main-is:             Test.hs
-  build-depends:       base, text,
-                       text-icu >= 0.6.3,
+  build-depends:       base, text >= 2.0,
+                       text-icu >= 0.8.0.0,
                        text-icu-translit,
                        QuickCheck >= 2.4,
                        test-framework >= 0.8,


### PR DESCRIPTION
This PR:
- adds proper support for `text-2.0` (as its internal representation changed to `Word8` from `Word16`)
- fixes a small error where `text-2.1.2`'s `Data.Text` exports `show`, which conflicts with `Prelude.show`
- bumps the version to `0.1.1.1`

Tested with `text-2.1.4` against `ghc-9.10.3` 👍